### PR TITLE
Fix page.description variable (for meta tag description) bug

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
 
 <title>{% if page.title %} {{ page.title }} {%endif%} Thelia Documentation</title>
 
-<meta name="description" content="{% if page.description %} {{ page.description }} {%endif%}">
+<meta name="description" content="{% if page.meta.description %} {{ page.meta.description }} {%endif%}">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,8 @@
 ---
 layout: welcome
 title: Welcome
-description: Thelia is an open source tool for creating e-business websites and managing online content. Learn to use it with this documentation.
+meta:
+    description: Thelia is an open source tool for creating e-business websites and managing online content. Learn to use it with this documentation.
 sidebar: welcome
 lang: en
 welcome :


### PR DESCRIPTION
This variable already existed and has been replaced by page.meta.description
