### PR TITLE
Fix syntaxe error yml format

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -119,7 +119,7 @@ languages:
             { name: "Front-office", sidebar_name: "templates_front_office", url: "/en/documentation/templates/front_office.html" },
             { name: "Back-office", sidebar_name: "templates_back_office", url: "/en/documentation/templates/back_office.html" },
             { name: "PDF", sidebar_name: "templates_pdf", url: "/en/documentation/templates/pdf.html" },
-            { name: "E-mails", sidebar_name: "templates_emails", url: "/en/documentation/templates/emails.html" },
+            { name: "E-mails", sidebar_name: "templates_emails", url: "/en/documentation/templates/emails.html" }
           ]
         }
       ]

--- a/en/documentation/loop/associated_content.md
+++ b/en/documentation/loop/associated_content.md
@@ -11,8 +11,8 @@ type: associated_content
 arguments :
     - {name: "product", description: "A single product id.", example: "product=\"2\"", mandatory: "double"}
     - {name: "category", description: "A single category id.", example: "category=\"5\"", mandatory: "double"}
-    - {name: "exclude_product", description: "A single or a list of product ids. If a content is in multiple products which are not all excluded it will not be excluded.", example: "exclude_product=\"5\"",}
-    - {name: "exclude_category", description: "A single or a list of category ids. If a content is in multiple categories which are not all excluded it will not be excluded.", example: "exclude_category=\"5\"",}
+    - {name: "exclude_product", description: "A single or a list of product ids. If a content is in multiple products which are not all excluded it will not be excluded.", example: "exclude_product=\"5\""}
+    - {name: "exclude_category", description: "A single or a list of category ids. If a content is in multiple categories which are not all excluded it will not be excluded.", example: "exclude_category=\"5\""}
     - {
         name: "order", description: "A list of values", example: "order=\"associated_content\"", default: "associated_content",
         expected_values: [


### PR DESCRIPTION
Error during jekyll compilation on "jekyll serve" command because of wrong yml syntax.
