### PR TITLE
error in loop documentation

### DIFF
--- a/en/documentation/modules/loops.md
+++ b/en/documentation/modules/loops.md
@@ -14,8 +14,8 @@ subnav: plugin_loop
 
 ```xml
 <loops>
-    <loop name="MyModule_Product" class="MyModule\Loop\Product" />
-    <loop name="MyModule_MyLoop" class="MyModule\Loop\MyLoop" />
+    <loop name="mymodule_product" class="MyModule\Loop\Product" />
+    <loop name="mymodule_myloop" class="MyModule\Loop\MyLoop" />
 </loops>
 ```
 
@@ -24,7 +24,7 @@ class properties are mandatory. The name is the loop name used into the template
 type="MyModule_Product">...</THELIA_name>```), class property is the class executed by the template engine. This
 class must extends the [Thelia\Core\Template\Element\BaseLoop](/api/master/Thelia/Core/Template/Element/BaseLoop.html)
 abstract class, if not an exception is thrown.
-**If you name your loop like a default loop (eg : Product), your loop will replace the default loop.**
+**If you name your loop like a default loop (eg : product), your loop will replace the default loop.**
 
 ##How to implement a loop ?
 
@@ -38,9 +38,9 @@ NB : You can also extend BaseI18nLoop which itself extends BaseLoop. This will p
 
 It's a matter of data type. If the data your loop returns come from the database you must implement *PropelSearchLoopInterface* and create *buildModelCriteria* method which return a *Propel\Runtime\ActiveQuery\ModelCriteria*. Conversely if your loop displays data from an array you must implement *ArraySearchLoopInterface* and create *buildArray* method which return an array.
 
-The *parseResults* method is used to render the template. It must return a [Thelia\Core\Template\Element\LoopResult](http://localhost:4000/api/master/Thelia/Core/Template/Element/LoopResult.html) instance.
+The *parseResults* method is used to render the template. It must return a [Thelia\Core\Template\Element\LoopResult](/api/master/Thelia/Core/Template/Element/LoopResult.html) instance.
 
-The defineArgs method defines all args used in your loop. Args can be mandatory, optional, with default value, etc. This method must return an [Thelia\Core\Template\Loop\ArgumentCollection](). ArgumentCollection contains [Thelia\Core\Template\Loop\Argument]() which contains a [Thelia\Type\TypeCollection](). Types in the collection must implement [Thelia\Type\TypeInterface](). You can check here the [available types](/documentation/features/types).
+The getArgDefinitions method defines all args used in your loop. Args can be mandatory, optional, with default value, etc. This method must return an [Thelia\Core\Template\Loop\ArgumentCollection](). ArgumentCollection contains [Thelia\Core\Template\Loop\Argument]() which contains a [Thelia\Type\TypeCollection](). Types in the collection must implement [Thelia\Type\TypeInterface](). You can check here the [available types](/documentation/features/types).
 
 If you don't define your arguments here, you can't use them in your new loop. All arguments are accessible in the ```parseResults``` method.
 
@@ -101,6 +101,9 @@ Here an example for my module "MyModule" and my loops in the loop directory. Thi
  use Thelia\Core\Template\Element\BaseLoop;
  use Thelia\Core\Template\Element\LoopResult;
  use Thelia\Core\Template\Element\LoopResultRow;
+ use Thelia\Core\Template\Element\ArraySearchLoopInterface;
+ use Thelia\Core\Template\Loop\Argument\ArgumentCollection;
+ use Thelia\Core\Template\Loop\Argument\Argument;
 
  class MyLoop extends BaseLoop implements ArraySearchLoopInterface {
 
@@ -108,7 +111,7 @@ Here an example for my module "MyModule" and my loops in the loop directory. Thi
     public $timestampable = false;
     public $versionable = false;
 
-     public function defineArgs()
+     public function getArgDefinitions()
      {
          return new ArgumentCollection(
              Argument::createIntListTypeArgument('start', 0),
@@ -161,8 +164,7 @@ Here an example for my module "MyModule" and my loops in the loop directory. Thi
 */
 public function buildModelCriteria()
 {
-    return $products = ProductQuery::create()
-         ->find();
+    return ProductQuery::create();
 }
 
 public function parseResults(LoopResult $loopResult)


### PR DESCRIPTION
- getArgDefinitions instead of defineArgs
- bad link on localhost
- loop name must be lowercase
- missing 'use'
- buildModelCriteria must return a query, not a collection
