### PR TITLE
Added new attributes and some aliases to the {cart} substitution

### DIFF
--- a/en/documentation/substitutions/cart.md
+++ b/en/documentation/substitutions/cart.md
@@ -7,9 +7,13 @@ lang: en
 subnav: substitution_cart
 prefix: cart
 attributes :
-    - {name: "count_item", description: "Item count"}
-    - {name: "total_price", description: "Total price without taxes "}
-    - {name: "total_taxed_price", description: "Total price with taxes"}
+    - {name: "product_count (or count_product)", description: "The number of distinct products in the cart. A cart with 2 x product X and 3 x product Y have 2 distinct products"}
+    - {name: "item_count (or count_item)", description: "The number of items in the cart. A cart with 2 x product X and 3 x product Y have 5 items"}
+    - {name: "total_price_with_discount (or total_price)", description: "Total cart amount in the current currency, without taxes, including discount, if any"}
+    - {name: "total_price_without_discount", description: "Total cart amount in the current currency, without taxes, excluding discount, if any"}
+    - {name: "total_taxed_price_with_discount (or total_taxed_price)", description: "Total cart amount in the current currency with taxes, and including the discount, if any."}
     - {name: "total_taxed_price_without_discount", description: "Total price with discount without taxes"}
+    - {name: "weight", description: "The cart total weight, in kg"}
+    - {name: "contains_virtual_product (or is_virtual)", description: "True if the cart contains at least one virtual product, false otherwise"}
 ---
 


### PR DESCRIPTION
This PR is add attributes to the `{cart}` substitution. See thelia/thelia#1725

1. A new `weight` attribute is added, to get the cart total weight.
2. A new `total_price_without_discount` attribute is added, to get the cart total amount without taxes, excluding discount.
3. The following aliases of existing attributes are added, to provide a better english syntax, or a more accurate name : 
  - `product_count`, alias of `count_product`
  - `item_count`, alias of `count_item`
  - `total_price_with_discount` alias of `total_price`
  - `total_taxed_price_with_discount` alias of `total_taxed_price`
  - `contains_virtual_product` alias of `is_virtual`
  - `total_tax_amount` alias of `total_vat`