### PR TITLE
Loop args fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-    - 2.3
+    - 2.2
 
 script: "bundle exec jekyll build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-    - 2.0.0
+    - 2.3
 
 script: "bundle exec jekyll build"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+gem 'rouge'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
-gem 'rouge'
-gem "jekyll", "3.1.6"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'github-pages'
 gem 'rouge'
+gem "jekyll", "3.1.6"

--- a/_includes/loop/argument_row.html
+++ b/_includes/loop/argument_row.html
@@ -49,7 +49,8 @@
                             <div class="expected_values">
                                 Expected values :
                                 <ul>
-                                    {% for expected_value in argument.expected_values %}
+                                    {% assign sorted_expected_values = (argument.expected_values | sort: 'name') %}
+                                    {% for expected_value in sorted_expected_values %}
                                     <li>
                                         {{ expected_value.name }}{% if expected_value.description != nil and expected_value.description != '' %} : <em>{{ expected_value.description }}</em>{% endif %}
                                         {% if expected_value.from_version != nil AND expected_value.from_version != '' %}
@@ -135,7 +136,8 @@
                                 <div class="expected_values">
                                     Expected values :
                                     <ul>
-                                        {% for expected_value in argument.expected_values %}
+                                        {% assign sorted_expected_values = (argument.expected_values | sort: 'name') %}
+                                        {% for expected_value in sorted_expected_values %}
                                         <li>
                                             {{ expected_value.name }}{% if expected_value.description != nil and expected_value.description != '' %} : <em>{{ expected_value.description }}</em>{% endif %}
                                             {% if expected_value.from_version != nil AND expected_value.from_version != '' %}
@@ -209,7 +211,8 @@
                     <div class="expected_values">
                         Expected values :
                         <ul>
-                            {% for expected_value in argument.expected_values %}
+                            {% assign sorted_expected_values = (argument.expected_values | sort: 'name') %}
+                            {% for expected_value in sorted_expected_values %}
                             <li>
                                 {{ expected_value.name }}{% if expected_value.description != nil and expected_value.description != '' %} : <em>{{ expected_value.description }}</em>{% endif %}
                                 {% if expected_value.from_version != nil AND expected_value.from_version != '' %}

--- a/en/documentation/loop/category.md
+++ b/en/documentation/loop/category.md
@@ -28,11 +28,19 @@ arguments :
     - {
         name: "order", description: "A list of values", example: "order=\"random\"", default: "manual",
         expected_values: [
+            {name: "id",                description: "order by ascending ID"},
+            {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
-            {name: "manual",            description: "`category` argument must be set"},
-            {name: "manual_reverse",    description: "`category` argument must be set"},
-            {name: "random",            description: ""}
+            {name: "manual",            description: "order by ascending position, relative to parent category"},
+            {name: "manual_reverse",    description: "order by descending position, relative to parent category"},
+            {name: "random",            description: ""},
+            {name: "created",           description: "ascending order on date of content creation"},
+            {name: "created_reverse",   description: "descending order on date of content creation"},
+            {name: "updated",           description: "ascending order on date of content update"},
+            {name: "updated_reverse",   description: "descending order on date of content update"},
+            {name: "position",          description: "order by ascending position, without considering a parent category"},
+            {name: "position_reverse",  description: "order by descending position, without considering a parent category"},            
         ]
       }
 outputs :

--- a/en/documentation/loop/category.md
+++ b/en/documentation/loop/category.md
@@ -32,15 +32,15 @@ arguments :
             {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
-            {name: "manual",            description: "order by ascending position, relative to parent category"},
-            {name: "manual_reverse",    description: "order by descending position, relative to parent category"},
-            {name: "random",            description: ""},
+            {name: "manual",            description: "order by ascending position"},
+            {name: "manual_reverse",    description: "order by descending position"},
+            {name: "visible",           description: "online items firts"},
+            {name: "visible_reverse",   description: "offline items first"},            
+            {name: "random",            description: "return categories in random order"},
             {name: "created",           description: "ascending order on date of content creation"},
             {name: "created_reverse",   description: "descending order on date of content creation"},
             {name: "updated",           description: "ascending order on date of content update"},
             {name: "updated_reverse",   description: "descending order on date of content update"},
-            {name: "position",          description: "order by ascending position, without considering a parent category"},
-            {name: "position_reverse",  description: "order by descending position, without considering a parent category"},            
         ]
       }
 outputs :

--- a/en/documentation/loop/content.md
+++ b/en/documentation/loop/content.md
@@ -24,14 +24,14 @@ arguments :
     - {name: "return_url", description: "A boolean value which allows the urls generation.", example: "return_url=\"no\"", default: "yes", from_version: "2.3"}
     - {name: "with_prev_next_info", description: "A boolean. If set to true, $PREVIOUS and $NEXT output arguments are available.", example: "with_prev_next_info=\"yes\"", default: "false"}
     - {
-        name: "order", description: "A list of values", example: "order=\"random\"", default: "manual",
+        name: "order", description: "A list of values", example: "order=\"random\"", default: "alpha",
         expected_values: [ 
             {name: "id",                description: "order by ascending ID"},
             {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
-            {name: "manual",            description: "order by ascending position"},
-            {name: "manual_reverse",    description: "order by descending position"},
+            {name: "manual",            description: "order by ascending position, considering a given folder. `folder` argument must be set"},
+            {name: "manual_reverse",    description: "order by descending position, considering a given folder. `folder` argument must be set"},
             {name: "visible",           description: "online items firts"},
             {name: "visible_reverse",   description: "offline items first"},                        
             {name: "random",            description: "return contents in random order"},
@@ -40,6 +40,8 @@ arguments :
             {name: "created_reverse",   description: "descending order on date of content creation"},
             {name: "updated",           description: "ascending order on date of content update"},
             {name: "updated_reverse",   description: "descending order on date of content update"},
+            {name: "position",          description: "order by ascending position, without considering a parent folder"},
+            {name: "position_reverse",  description: "order by descending position, without considering a parent folder"},
         ]
       }
 outputs :

--- a/en/documentation/loop/content.md
+++ b/en/documentation/loop/content.md
@@ -25,17 +25,23 @@ arguments :
     - {name: "with_prev_next_info", description: "A boolean. If set to true, $PREVIOUS and $NEXT output arguments are available.", example: "with_prev_next_info=\"yes\"", default: "false"}
     - {
         name: "order", description: "A list of values", example: "order=\"random\"", default: "manual",
-        expected_values: [
+        expected_values: [ 
+            {name: "id",                description: "order by ascending ID"},
+            {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
             {name: "manual",            description: "`content` argument must be set"},
             {name: "manual_reverse",    description: "`content` argument must be set"},
-            {name: "random",            description: ""},
+            {name: "visible",           description: "online items firts"},
+            {name: "visible_reverse",   description: "offline items first"},                        
+            {name: "random",            description: "return contents in random order"},
             {name: "given_id",          description: "return the same order received in `id` argument which therefore must be set"},
             {name: "created",           description: "ascending order on date of content creation"},
             {name: "created_reverse",   description: "descending order on date of content creation"},
             {name: "updated",           description: "ascending order on date of content update"},
             {name: "updated_reverse",   description: "descending order on date of content update"},
+            {name: "position",          description: "order by ascending position, without considering a parent folder"},
+            {name: "position_reverse",  description: "order by descending position, without considering a parent folder"},
         ]
       }
 outputs :

--- a/en/documentation/loop/content.md
+++ b/en/documentation/loop/content.md
@@ -30,8 +30,8 @@ arguments :
             {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
-            {name: "manual",            description: "`content` argument must be set"},
-            {name: "manual_reverse",    description: "`content` argument must be set"},
+            {name: "manual",            description: "order by ascending position"},
+            {name: "manual_reverse",    description: "order by descending position"},
             {name: "visible",           description: "online items firts"},
             {name: "visible_reverse",   description: "offline items first"},                        
             {name: "random",            description: "return contents in random order"},
@@ -40,8 +40,6 @@ arguments :
             {name: "created_reverse",   description: "descending order on date of content creation"},
             {name: "updated",           description: "ascending order on date of content update"},
             {name: "updated_reverse",   description: "descending order on date of content update"},
-            {name: "position",          description: "order by ascending position, without considering a parent folder"},
-            {name: "position_reverse",  description: "order by descending position, without considering a parent folder"},
         ]
       }
 outputs :

--- a/en/documentation/loop/folder.md
+++ b/en/documentation/loop/folder.md
@@ -23,15 +23,21 @@ arguments :
     - {
         name: "order", description: "A list of values", example: "order=\"random\"", default: "manual",
         expected_values: [
+            {name: "id",                description: "order by ascending ID"},
+            {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
-            {name: "manual",            description: "`folder` argument must be set"},
-            {name: "manual_reverse",    description: "`folder` argument must be set"},
+            {name: "manual",            description: "order by ascending position relative to the parent folder"},
+            {name: "manual_reverse",    description: "order by descending position relative to the parent folder"},
+            {name: "visible",           description: "online items firts"},
+            {name: "visible_reverse",   description: "offline items first"},            
             {name: "random",            description: ""},
             {name: "created",           description: "ascending order on date of content creation"},
             {name: "created_reverse",   description: "descending order on date of content creation"},
             {name: "updated",           description: "ascending order on date of content update"},
-            {name: "updated_reverse",   description: "descending order on date of content update"}
+            {name: "updated_reverse",   description: "descending order on date of content update"},
+            {name: "position",          description: "order by ascending position, without considering a parent folder"},
+            {name: "position_reverse",  description: "order by descending position, without considering a parent folder"}           
         ]
       }
 outputs :

--- a/en/documentation/loop/folder.md
+++ b/en/documentation/loop/folder.md
@@ -27,17 +27,15 @@ arguments :
             {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
-            {name: "manual",            description: "order by ascending position relative to the parent folder"},
-            {name: "manual_reverse",    description: "order by descending position relative to the parent folder"},
+            {name: "manual",            description: "order by ascending position"},
+            {name: "manual_reverse",    description: "order by descending position"},
             {name: "visible",           description: "online items firts"},
             {name: "visible_reverse",   description: "offline items first"},            
-            {name: "random",            description: ""},
+            {name: "random",            description: "return folders in random order"},
             {name: "created",           description: "ascending order on date of content creation"},
             {name: "created_reverse",   description: "descending order on date of content creation"},
             {name: "updated",           description: "ascending order on date of content update"},
             {name: "updated_reverse",   description: "descending order on date of content update"},
-            {name: "position",          description: "order by ascending position, without considering a parent folder"},
-            {name: "position_reverse",  description: "order by descending position, without considering a parent folder"}           
         ]
       }
 outputs :

--- a/en/documentation/loop/product.md
+++ b/en/documentation/loop/product.md
@@ -63,16 +63,27 @@ arguments :
     - {
         name: "order", description: "A list of values", example: "order=\"category,min_price\"", default: "alpha",
         expected_values: [
+            {name: "id",                description: "order by ascending ID"},
+            {name: "id_reverse",        description: "order by descending ID"},
             {name: "alpha",             description: "alphabetical order on title"},
             {name: "alpha_reverse",     description: "reverse alphabetical order on title"},
             {name: "min_price",         description: "ascending price"},
             {name: "max_price",         description: "descending price"},
-            {name: "manual",            description: "`category` argument must be set"},
-            {name: "manual_reverse",    description: "`category` argument must be set"},
+            {name: "manual",            description: "order by ascending position considering a given category. `category` argument must be set"},
+            {name: "manual_reverse",    description: "order by ascending position considering a given category. `category` argument must be set"},
+            {name: "visible",           description: "online items firts"},
+            {name: "visible_reverse",   description: "offline items first"},
+            {name: "created",           description: "ascending order on date of content creation"},
+            {name: "created_reverse",   description: "descending order on date of content creation"},
+            {name: "updated",           description: "ascending order on date of content update"},
+            {name: "updated_reverse",   description: "descending order on date of content update"},
             {name: "ref",               description: "alphabetical order on reference"},
+            {name: "ref_reverse",       description: "reverse alphabetical order on reference"},
+            {name: "position",          description: "order by ascending position, without considering a parent category"},
+            {name: "position_reverse",  description: "order by descending position, without considering a parent category"},
             {name: "promo",             description: "promo products first"},
             {name: "new",               description: "new products first"},
-            {name: "random",            description: ""},
+            {name: "random",            description: "return products in random order"},
             {name: "given_id",          description: "return the same order received in `id` argument which therefore must be set"}
         ]
       }


### PR DESCRIPTION
Fixed content, folder and category loops "order"  arguments values.

All "order" argument values are now sorted in alphabetical ascending order.