### PR TITLE
Coupon substitutions and feed loop

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -167,6 +167,7 @@ languages:
             { name: "Feature loop", sidebar_name: "loop_feature", url: "/en/documentation/loop/feature.html" },
             { name: "Feature availability loop", sidebar_name: "loop_feature_availability", url: "/en/documentation/loop/feature_availability.html" },
             { name: "Feature value loop", sidebar_name: "loop_feature_value", url: "/en/documentation/loop/feature_value.html" },
+            { name: "Feed loop", sidebar_name: "loop_feed", url: "/en/documentation/loop/feed.html" },
             { name: "Folder loop", sidebar_name: "loop_folder", url: "/en/documentation/loop/folder.html" },
             { name: "Folder path loop", sidebar_name: "loop_folder_path", url: "/en/documentation/loop/folder_path.html" },
             { name: "Folder tree loop", sidebar_name: "loop_folder_tree", url: "/en/documentation/loop/folder_tree.html" },

--- a/_config.yml
+++ b/_config.yml
@@ -218,6 +218,7 @@ languages:
             { name: "Config", sidebar_name: "substitution_config", url: "/en/documentation/substitutions/config.html" },
             { name: "Content", sidebar_name: "substitution_content", url: "/en/documentation/substitutions/content.html" },
             { name: "Country", sidebar_name: "substitution_country", url: "/en/documentation/substitutions/country.html" },
+            { name: "Coupon", sidebar_name: "substitution_coupon", url: "/en/documentation/substitutions/coupon.html" },
             { name: "Customer", sidebar_name: "substitution_customer", url: "/en/documentation/substitutions/customer.html" },
             { name: "Currency", sidebar_name: "substitution_currency", url: "/en/documentation/substitutions/currency.html" },
             { name: "Folder", sidebar_name: "substitution_folder", url: "/en/documentation/substitutions/folder.html" },

--- a/_includes/substitution/argument_row.html
+++ b/_includes/substitution/argument_row.html
@@ -13,6 +13,13 @@
             </td>
             <td>
                 {{ argument.description }}
+                {% if argument.from_version != nil AND argument.from_version != '' %}
+                    <span class="label label-info" title="From version {{ argument.from_version }}">&gt;= {{ argument.from_version }}</span>
+                {% endif %}
+                {% if argument.until_version != nil AND argument.until_version != '' %}
+                    <span class="label label-default" title="Until version {{ argument.until_version }}">&lt; {{ argument.until_version }}</span>
+                {% endif %}
+
             </td>
         </tr>
         {% endfor %}

--- a/_includes/substitution/attribute_row.html
+++ b/_includes/substitution/attribute_row.html
@@ -13,6 +13,13 @@
             </td>
             <td>
                 {{ attribute.description }}
+                
+                {% if attribute.from_version != nil AND attribute.from_version != '' %}
+                    <span class="label label-info" title="From version {{ attribute.from_version }}">&gt;= {{ attribute.from_version }}</span>
+                {% endif %}
+                {% if attribute.until_version != nil AND attribute.until_version != '' %}
+                    <span class="label label-default" title="Until version {{ attribute.until_version }}">&lt; {{ argument.until_version }}</span>
+                {% endif %}
             </td>
         </tr>
         {% endfor %}

--- a/en/documentation/loop/feed.md
+++ b/en/documentation/loop/feed.md
@@ -1,0 +1,20 @@
+---
+layout: loop
+title: Feed Loop
+description: Get data from an Atom or RSS feed.
+sidebar: loop
+lang: en
+subnav: loop_feed
+uses_global_argument: true
+returns_global_outputs: { countable : true, timestampable : false, versionable : false }
+type: feed
+arguments :
+    - {name: "url", mandatory: true, description: "An Atom or RSS feed URL.", example: "url='http://thelia.net/feeds/?lang=en'"}
+    - {name: "timeout", description: "Delay in seconds after which the loop closes the connection with the remote server", example: "timeout=10"}
+outputs :
+    - {name: "$URL", description: "the feed item URL"}
+    - {name: "$TITLE", description: "The feed item title"}
+    - {name: "$AUTHOR", description: "The feed item author"}
+    - {name: "$DESCRIPTION", description: "The feed item description"}
+    - {name: "$DATE", description: "the feed item date, as a Unix timestamp"}
+---

--- a/en/documentation/substitutions/coupon.md
+++ b/en/documentation/substitutions/coupon.md
@@ -1,0 +1,15 @@
+---
+layout: substitution
+title: Coupon Substitution
+description: Return informations on the coupons defined during the purchase process
+sidebar: substitution
+lang: en
+subnav: substitution_coupon
+prefix: coupon
+from_version: "2.3.4"
+attributes :
+    - {name: "has_coupons", description: "True is some coupons are currently in use, false otherwise", from_version: "2.3.4"}
+    - {name: "coupon_count", description: "Number of coupons currently in use", from_version: "2.3.4"}
+    - {name: "coupon_list", description: "An array containing the code of coupons currently in use.", from_version: "2.3.4"}
+    - {name: "is_delivery_free", description: "True if at least one of the coupons currently in use gives free delivery, false otherwise", from_version: "2.3.4"}
+---

--- a/en/documentation/substitutions/order.md
+++ b/en/documentation/substitutions/order.md
@@ -7,10 +7,13 @@ lang: en
 subnav: substitution_order
 prefix: order
 attributes :
-    - {name: "postage", description: "Shipping amount"}
+    - {name: "untaxed_postage", description: "Shipping amount without taxes"}
+    - {name: "postage", description: "Shipping amount with taxes"}
+    - {name: "postage_tax", description: "Shipping tax amount"}
     - {name: "discount", description: "Discount amount"}
     - {name: "delivery_address", description: "The delivery address ID"}
     - {name: "invoice_address", description: "The invoice address ID"}
     - {name: "delivery_module", description: "The delivery module ID"}
     - {name: "payment_module", description: "The payment module ID"}
+    - {name: "has_virtual_product", description: "true is the order contains virtual products, false otherwise"}
 ---


### PR DESCRIPTION
This PR documents the new coupons substitutions (>= 2.3.4) and the feed loop, which was forgotten.